### PR TITLE
Implementiere Farb- und Tag-System für Blackboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,14 @@
 8. IMMER nach der Abarbeitung eines Problems oder Features nachfragen, was als nächstes gemacht werden soll
 9. NACH JEDEM FIX auf die Überprüfung des Nutzers warten und erst nach dessen Bestätigung weitermachen
 
+## Git-Workflow (AB SOFORT - SEHR WICHTIG!)
+- **IMMER Feature-Branches erstellen** - NIE direkt auf master pushen!
+- **VOR jedem Commit fragen**: "Soll ich Feature-Branch erstellen?"
+- **Branch-Namen vorschlagen**: feature/blackboard-colors, feature/calendar-fix, etc.
+- **Pull Requests**: Für Code Review vor Merge in master
+- **Workflow**: git checkout -b feature/name → develop → push branch → PR
+- **Ausnahme nur**: Wenn Simon explizit sagt "push direkt auf master"
+
 ## Projektübersicht
 - **Name**: Assixx (SaaS-Plattform für Industriefirmen)
 - **Zielgruppe**: Industriefirmen mit Produktionsarbeitern ohne PC-Zugang

--- a/server/database/migrations/add_blackboard_colors_tags.sql
+++ b/server/database/migrations/add_blackboard_colors_tags.sql
@@ -1,0 +1,39 @@
+-- Add color and tags functionality to blackboard entries
+-- Migration: Blackboard Colors and Tags Feature
+
+-- Add color field to blackboard_entries table
+ALTER TABLE blackboard_entries 
+ADD COLUMN color VARCHAR(20) DEFAULT 'blue' AFTER priority;
+
+-- Create tags table
+CREATE TABLE IF NOT EXISTS blackboard_tags (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    tenant_id INT NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    color VARCHAR(20) DEFAULT 'blue',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE KEY unique_tag_per_tenant (tenant_id, name)
+);
+
+-- Create junction table for entry-tag relationships
+CREATE TABLE IF NOT EXISTS blackboard_entry_tags (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    entry_id INT NOT NULL,
+    tag_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (entry_id) REFERENCES blackboard_entries(id) ON DELETE CASCADE,
+    FOREIGN KEY (tag_id) REFERENCES blackboard_tags(id) ON DELETE CASCADE,
+    UNIQUE KEY unique_entry_tag (entry_id, tag_id)
+);
+
+-- Insert some default tags for testing
+INSERT IGNORE INTO blackboard_tags (tenant_id, name, color) VALUES
+(1, 'Wichtig', 'red'),
+(1, 'Info', 'blue'),
+(1, 'Wartung', 'orange'),
+(1, 'Meeting', 'green'),
+(1, 'Sicherheit', 'red'),
+(1, 'Event', 'purple'),
+(1, 'Update', 'blue'),
+(1, 'Deadline', 'red');

--- a/server/public/blackboard.html
+++ b/server/public/blackboard.html
@@ -254,6 +254,38 @@
             <input type="date" class="big-input" id="entryExpiresAt">
           </div>
           
+          <!-- Farbe auswählen -->
+          <div class="form-group large-form-group">
+            <label class="big-label">Farbe des Eintrags</label>
+            <div class="color-picker">
+              <button type="button" class="color-option active" data-color="blue" style="background: #2196F3;">
+                <span>💙</span> Blau
+              </button>
+              <button type="button" class="color-option" data-color="green" style="background: #4CAF50;">
+                <span>💚</span> Grün
+              </button>
+              <button type="button" class="color-option" data-color="orange" style="background: #FF9800;">
+                <span>🧡</span> Orange
+              </button>
+              <button type="button" class="color-option" data-color="red" style="background: #F44336;">
+                <span>❤️</span> Rot
+              </button>
+              <button type="button" class="color-option" data-color="purple" style="background: #9C27B0;">
+                <span>💜</span> Lila
+              </button>
+              <button type="button" class="color-option" data-color="gray" style="background: #757575;">
+                <span>🖤</span> Grau
+              </button>
+            </div>
+          </div>
+          
+          <!-- Tags hinzufügen -->
+          <div class="form-group large-form-group">
+            <label for="entryTags" class="big-label">Tags (mit Komma trennen)</label>
+            <input type="text" class="big-input" id="entryTags" placeholder="Wichtig, Meeting, Update...">
+            <div class="simple-hint">Beispiele: Wichtig, Meeting, Wartung, Sicherheit</div>
+          </div>
+          
           <!-- Checkbox für Bestätigung -->
           <div class="form-group large-form-group">
             <div class="simple-checkbox">

--- a/server/public/css/blackboard.css
+++ b/server/public/css/blackboard.css
@@ -529,6 +529,45 @@
   box-shadow: 0 0 0 3px rgba(33, 150, 243, 0.1);
 }
 
+/* Color Picker */
+.color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.color-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 2px solid transparent;
+  border-radius: 20px;
+  color: white;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+
+.color-option:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+  border-color: rgba(255,255,255,0.3);
+}
+
+.color-option.active {
+  border-color: white;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+}
+
+.color-option span {
+  font-size: 16px;
+}
+
 /* Grid Layout */
 .row {
   display: flex;

--- a/server/routes/blackboard.js
+++ b/server/routes/blackboard.js
@@ -238,6 +238,8 @@ router.post('/api/blackboard',
         author_id: req.user.id,
         expires_at: req.body.expires_at || null,
         priority: req.body.priority || 'normal',
+        color: req.body.color || 'blue',
+        tags: req.body.tags || [],
         requires_confirmation: req.body.requires_confirmation || false
       };
       
@@ -265,7 +267,16 @@ router.put('/api/blackboard/:id',
     try {
       const entryData = {
         author_id: req.user.id,
-        ...req.body
+        title: req.body.title,
+        content: req.body.content,
+        org_level: req.body.org_level,
+        org_id: req.body.org_id,
+        priority: req.body.priority,
+        color: req.body.color,
+        tags: req.body.tags,
+        expires_at: req.body.expires_at,
+        requires_confirmation: req.body.requires_confirmation,
+        status: req.body.status
       };
       
       // Da die tenant_id in der DB ein Integer ist, konvertieren wir auf einen Standardwert
@@ -366,6 +377,25 @@ router.get('/api/blackboard/:id/confirmations',
     } catch (error) {
       console.error('Error in GET /api/blackboard/:id/confirmations:', error);
       res.status(500).json({ message: 'Error retrieving confirmation status' });
+    }
+  });
+
+/**
+ * @route GET /api/blackboard/:id/tags
+ * @desc Get tags for a specific entry
+ */
+router.get('/api/blackboard/:id/tags', 
+  authenticateToken, 
+  tenantMiddleware, 
+  // Temporarily disabled for debugging
+  // checkFeature('blackboard_system'),
+  async (req, res) => {
+    try {
+      const tags = await blackboardModel.getEntryTags(req.params.id);
+      res.json(tags);
+    } catch (error) {
+      console.error('Error in GET /api/blackboard/:id/tags:', error);
+      res.status(500).json({ message: 'Error retrieving entry tags' });
     }
   });
 


### PR DESCRIPTION
- Füge 6 Farboptionen für Blackboard-Einträge hinzu (Blau, Grün, Orange, Rot, Lila, Grau)
- Implementiere Tag-System mit Datenbank-Schema und Junction-Tables
- Erweitere Blackboard-Model um Farb- und Tag-Unterstützung
- Modernisiere UI mit Glassmorphismus-Design und Pill-Buttons
- Füge Farbauswahl und Tag-Input zum Erstellen-/Bearbeiten-Formular hinzu
- Implementiere visuelle Farbdarstellung in Einträgen (Border und Titel)
- Erweitere API-Routen um Farb- und Tag-Parameter
- Verbessere Edit-Funktionalität mit Vorausfüllung aller Felder
- Erstelle Datenbank-Migration für neue Spalten und Tabellen

🤖 Generated with [Claude Code](https://claude.ai/code)